### PR TITLE
⚡ optimize(hooks): throttle resize event listener in useResizeWatcher

### DIFF
--- a/src/hooks/resize-watcher.spec.ts
+++ b/src/hooks/resize-watcher.spec.ts
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+
+import { useResizeWatcher } from './resize-watcher';
+
+describe('useResizeWatcher', () => {
+    it('throttles resize events', async () => {
+        vi.useFakeTimers();
+        const callback = vi.fn();
+
+        const TestComponent = defineComponent({
+            setup() {
+                useResizeWatcher(callback);
+                return {};
+            },
+            template: '<div></div>'
+        });
+
+        const wrapper = mount(TestComponent);
+
+        // Simulate 10 resize events over 100ms
+        for (let i = 0; i < 10; i++) {
+            window.dispatchEvent(new Event('resize'));
+            vi.advanceTimersByTime(10);
+        }
+
+        // Throttle is 200ms. Leading edge executes immediately.
+        // We are at T=100ms, so only the first call should have happened.
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        // Advance time to allow the trailing edge execution (at T=200ms)
+        vi.advanceTimersByTime(100);
+        expect(callback).toHaveBeenCalledTimes(2);
+
+        wrapper.unmount();
+        vi.useRealTimers();
+    });
+});

--- a/src/hooks/resize-watcher.ts
+++ b/src/hooks/resize-watcher.ts
@@ -1,8 +1,17 @@
+import { throttle } from 'lodash';
 import { onActivated, onBeforeUnmount, onDeactivated, onMounted } from 'vue';
 
 export function useResizeWatcher(fn: () => void) {
-    onMounted(() => window.addEventListener('resize', fn));
-    onActivated(() => window.addEventListener('resize', fn));
-    onDeactivated(() => window.removeEventListener('resize', fn));
-    onBeforeUnmount(() => window.removeEventListener('resize', fn));
+    const throttledFn = throttle(fn, 200);
+
+    onMounted(() => window.addEventListener('resize', throttledFn));
+    onActivated(() => window.addEventListener('resize', throttledFn));
+    onDeactivated(() => {
+        window.removeEventListener('resize', throttledFn);
+        throttledFn.cancel();
+    });
+    onBeforeUnmount(() => {
+        window.removeEventListener('resize', throttledFn);
+        throttledFn.cancel();
+    });
 }


### PR DESCRIPTION
*   💡 **What:** Added `lodash.throttle` to the resize event listener in `useResizeWatcher`.
*   🎯 **Why:** Resize events fire rapidly, causing performance issues. Throttling ensures the callback runs at most once every 200ms.
*   📊 **Measured Improvement:** Created a benchmark test `src/hooks/resize-watcher.spec.ts` that simulates rapid resize events.
    *   **Baseline:** The callback was executed on every resize event (10 calls for 10 events in 100ms).
    *   **Optimized:** The callback is executed at most once every 200ms (1 call for 10 events in 100ms, with a trailing call at 200ms).
    *   **Cleanup:** Properly removes listeners and cancels pending throttled calls on unmount/deactivation to prevent memory leaks.

---
*PR created automatically by Jules for task [3292861760969693642](https://jules.google.com/task/3292861760969693642) started by @fergusean*