### PR TITLE
Implement proper text deselection in context menu

### DIFF
--- a/src/helpers/context-menu.test.ts
+++ b/src/helpers/context-menu.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+import { showContextMenu } from './context-menu';
+
+describe('showContextMenu', () => {
+    let mockRemoveAllRanges: Mock;
+    let target: HTMLElement;
+
+    beforeEach(() => {
+        // Mock getSelection
+        mockRemoveAllRanges = vi.fn();
+        window.getSelection = vi.fn().mockReturnValue({
+            removeAllRanges: mockRemoveAllRanges
+        });
+
+        // Setup DOM
+        document.body.innerHTML = '<div id="target">Content</div>';
+        target = document.getElementById('target') as HTMLElement;
+    });
+
+    it('should programmatically deselect text and not use CSS to hide selection', () => {
+        const mouseEvent = new MouseEvent('contextmenu', {
+            bubbles: true,
+            cancelable: true,
+            clientX: 100,
+            clientY: 100
+        });
+        Object.defineProperty(mouseEvent, 'currentTarget', { value: target, writable: true });
+
+        showContextMenu(mouseEvent, { items: [] });
+
+        // Assert new behavior: CSS NOT modified
+        expect(target.style.userSelect).toBe('');
+
+        // Assert new behavior: Programmatic deselection called
+        expect(mockRemoveAllRanges).toHaveBeenCalled();
+    });
+});

--- a/src/helpers/context-menu.ts
+++ b/src/helpers/context-menu.ts
@@ -12,6 +12,8 @@ interface ContextMenuConfig {
 }
 
 export function showContextMenu(e: MouseEvent, config: ContextMenuConfig) {
+    window.getSelection()?.removeAllRanges();
+
     const wrapperEl = document.createElement('div');
     wrapperEl.classList.add('vf-overlay');
     wrapperEl.addEventListener('click', closeMenu);
@@ -23,7 +25,6 @@ export function showContextMenu(e: MouseEvent, config: ContextMenuConfig) {
     wrapperEl.appendChild(menuEl);
 
     const target = e.currentTarget as HTMLElement;
-    target.style.userSelect = 'none';
     target.classList.add('context-menu-active');
 
     if (config.targetClass) {
@@ -80,7 +81,6 @@ export function showContextMenu(e: MouseEvent, config: ContextMenuConfig) {
         }
 
         target.classList.remove('context-menu-active');
-        target.style.userSelect = '';
 
         wrapperEl.remove();
     }
@@ -104,5 +104,3 @@ export function showContextMenu(e: MouseEvent, config: ContextMenuConfig) {
         e.stopPropagation();
     }
 }
-
-// TODO: actually de-select text rather than just using CSS to hide its selection


### PR DESCRIPTION
Replaced CSS text hiding with programmatic deselection using standard DOM APIs. Added a unit test to verify the fix.

---
*PR created automatically by Jules for task [12088047757880807627](https://jules.google.com/task/12088047757880807627) started by @fergusean*