### PR TITLE
⚡ Optimize infinite scroll ancestor discovery to prevent layout thrashing

### DIFF
--- a/src/hooks/__tests__/infinite-scroll-perf.spec.ts
+++ b/src/hooks/__tests__/infinite-scroll-perf.spec.ts
@@ -36,7 +36,7 @@ describe('discoverScrollableAncestorEl Performance', () => {
     });
 
     it('should find the scrollable ancestor correctly', () => {
-        const ancestor = discoverScrollableAncestorEl(items[0]);
+        const ancestor = discoverScrollableAncestorEl(items[0]!);
         expect(ancestor).toBe(container);
     });
 
@@ -59,21 +59,21 @@ describe('discoverScrollableAncestorEl Performance', () => {
 
     it('should invalidate cache on next tick', async () => {
         // First check
-        const ancestor1 = discoverScrollableAncestorEl(items[0]);
+        const ancestor1 = discoverScrollableAncestorEl(items[0]!);
         expect(ancestor1).toBe(container);
 
         // Change structure: make List scrollable
         list.style.overflow = 'auto';
 
         // Immediate check (should be cached and return OLD ancestor)
-        const ancestor2 = discoverScrollableAncestorEl(items[0]);
+        const ancestor2 = discoverScrollableAncestorEl(items[0]!);
         expect(ancestor2).toBe(container); // Stale result proves caching is active
 
         // Wait for next tick to invalidate cache
-        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise((resolve) => setTimeout(resolve, 0));
 
         // Check again
-        const ancestor3 = discoverScrollableAncestorEl(items[0]);
+        const ancestor3 = discoverScrollableAncestorEl(items[0]!);
         // Now it should be 'list' because cache was cleared and it re-evaluated
         expect(ancestor3).toBe(list);
     });

--- a/src/hooks/__tests__/infinite-scroll-perf.spec.ts
+++ b/src/hooks/__tests__/infinite-scroll-perf.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { discoverScrollableAncestorEl } from '../infinite-scroll';
+
+describe('discoverScrollableAncestorEl Performance', () => {
+    let container: HTMLElement;
+    let list: HTMLElement;
+    let items: HTMLElement[];
+
+    beforeEach(() => {
+        // Setup DOM
+        // Container (scrollable) -> Wrapper -> Wrapper -> List -> Items (1000)
+        container = document.createElement('div');
+        container.style.overflow = 'auto';
+        document.body.appendChild(container);
+
+        let currentParent = container;
+        for (let i = 0; i < 5; i++) {
+            const div = document.createElement('div');
+            currentParent.appendChild(div);
+            currentParent = div;
+        }
+
+        list = currentParent;
+        items = [];
+        for (let i = 0; i < 1000; i++) {
+            const item = document.createElement('div');
+            list.appendChild(item);
+            items.push(item);
+        }
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.restoreAllMocks();
+    });
+
+    it('should find the scrollable ancestor correctly', () => {
+        const ancestor = discoverScrollableAncestorEl(items[0]);
+        expect(ancestor).toBe(container);
+    });
+
+    it('should minimize getComputedStyle calls', () => {
+        const spy = vi.spyOn(window, 'getComputedStyle');
+
+        // Run discovery for all 1000 items
+        for (const item of items) {
+            discoverScrollableAncestorEl(item);
+        }
+
+        const callCount = spy.mock.calls.length;
+        console.log(`getComputedStyle called ${callCount} times for 1000 items.`);
+
+        // Without optimization, this will be around 7000.
+        // We want it to be much lower, ideally close to the depth of the tree (e.g., < 20).
+        // Setting a threshold that clearly indicates optimization.
+        expect(callCount).toBeLessThan(100);
+    });
+
+    it('should invalidate cache on next tick', async () => {
+        // First check
+        const ancestor1 = discoverScrollableAncestorEl(items[0]);
+        expect(ancestor1).toBe(container);
+
+        // Change structure: make List scrollable
+        list.style.overflow = 'auto';
+
+        // Immediate check (should be cached and return OLD ancestor)
+        const ancestor2 = discoverScrollableAncestorEl(items[0]);
+        expect(ancestor2).toBe(container); // Stale result proves caching is active
+
+        // Wait for next tick to invalidate cache
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // Check again
+        const ancestor3 = discoverScrollableAncestorEl(items[0]);
+        // Now it should be 'list' because cache was cleared and it re-evaluated
+        expect(ancestor3).toBe(list);
+    });
+});

--- a/src/hooks/__tests__/infinite-scroll-perf.spec.ts
+++ b/src/hooks/__tests__/infinite-scroll-perf.spec.ts
@@ -70,7 +70,7 @@ describe('discoverScrollableAncestorEl Performance', () => {
         expect(ancestor2).toBe(container); // Stale result proves caching is active
 
         // Wait for next tick to invalidate cache
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
 
         // Check again
         const ancestor3 = discoverScrollableAncestorEl(items[0]!);

--- a/src/hooks/infinite-scroll.ts
+++ b/src/hooks/infinite-scroll.ts
@@ -60,20 +60,54 @@ export function uninstallScrollHook(cmp: InfiniteScrollComponent) {
 }
 
 const ScrollableOverflowValues = ['auto', 'scroll'];
-function discoverScrollableAncestorEl(el: Element): Element | null {
-    const parent = el.parentElement;
-    if (!parent) return null;
 
-    const computedStyle = window.getComputedStyle(parent);
-    if (
-        ScrollableOverflowValues.includes(computedStyle.overflow) ||
-        ScrollableOverflowValues.includes(computedStyle.overflowX) ||
-        ScrollableOverflowValues.includes(computedStyle.overflowY)
-    ) {
+let scrollableAncestorCache = new WeakMap<Element, Element | null>();
+let isScrollableCache = new WeakMap<Element, boolean>();
+let cacheInvalidationScheduled = false;
+
+function ensureCache() {
+    if (!cacheInvalidationScheduled) {
+        // Schedule invalidation on the next tick
+        setTimeout(() => {
+            scrollableAncestorCache = new WeakMap();
+            isScrollableCache = new WeakMap();
+            cacheInvalidationScheduled = false;
+        }, 0);
+        cacheInvalidationScheduled = true;
+    }
+}
+
+export function discoverScrollableAncestorEl(el: Element): Element | null {
+    ensureCache();
+
+    if (scrollableAncestorCache.has(el)) {
+        return scrollableAncestorCache.get(el) ?? null;
+    }
+
+    const parent = el.parentElement;
+    if (!parent) {
+        scrollableAncestorCache.set(el, null);
+        return null;
+    }
+
+    let isParentScrollable = isScrollableCache.get(parent);
+    if (isParentScrollable === undefined) {
+        const computedStyle = window.getComputedStyle(parent);
+        isParentScrollable =
+            ScrollableOverflowValues.includes(computedStyle.overflow) ||
+            ScrollableOverflowValues.includes(computedStyle.overflowX) ||
+            ScrollableOverflowValues.includes(computedStyle.overflowY);
+        isScrollableCache.set(parent, isParentScrollable);
+    }
+
+    if (isParentScrollable) {
+        scrollableAncestorCache.set(el, parent);
         return parent;
     }
 
-    return discoverScrollableAncestorEl(parent);
+    const ancestor = discoverScrollableAncestorEl(parent);
+    scrollableAncestorCache.set(el, ancestor);
+    return ancestor;
 }
 
 // TODO: switch to intersection observer

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,5 +1,7 @@
 {
     "extends": "./tsconfig.app.json",
+    "include": ["src/**/*.ts", "src/**/*.vue", "src/**/__tests__/*"],
+    "exclude": [],
     "compilerOptions": {
         "composite": false,
         "lib": [],


### PR DESCRIPTION
💡 **What:**
- Implemented a transient cache (valid for one tick) for `discoverScrollableAncestorEl`.
- The cache stores both "is scrollable" checks and "scrollable ancestor" results.
- The cache is automatically cleared on the next tick using `setTimeout`.

🎯 **Why:**
- `discoverScrollableAncestorEl` recursively calls `getComputedStyle`, which forces synchronous layout (reflow).
- When mounting a list of items (e.g., 1000 items), this resulted in O(N * Depth) calls, causing significant layout thrashing.
- With the cache, the first item traverses the tree (Depth calls), and subsequent items hit the cache (constant time).
- The transient nature ensures correctness against dynamic style changes (e.g., resize) in subsequent ticks.

📊 **Measured Improvement:**
- **Baseline:** ~6000 calls to `getComputedStyle` for 1000 items (depth ~6).
- **Optimized:** 6 calls to `getComputedStyle` for 1000 items.
- **Improvement:** ~1000x reduction in layout thrashing during batch mount.


---
*PR created automatically by Jules for task [10207345128597008368](https://jules.google.com/task/10207345128597008368) started by @fergusean*