### PR TITLE
Use MutationObserver for Tooltip Cleanup

### DIFF
--- a/src/directives/__tests__/tooltip.spec.ts
+++ b/src/directives/__tests__/tooltip.spec.ts
@@ -1,0 +1,76 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+
+import { vTooltip } from '../tooltip';
+
+// Mock showAlert to avoid external dependencies
+vi.mock('@/components', () => ({
+    showAlert: vi.fn()
+}));
+
+const TestComponent = defineComponent({
+    directives: {
+        tooltip: vTooltip
+    },
+    template: '<div id="target" v-tooltip="\'Test Tooltip\'" html>Hover me</div>'
+});
+
+describe('vTooltip', () => {
+    beforeEach(() => {
+        // Clear document body before each test
+        document.body.innerHTML = '';
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('shows tooltip on mouseenter', async () => {
+        const wrapper = mount(TestComponent, { attachTo: document.body });
+        const target = wrapper.find('#target');
+
+        // Trigger mouseenter
+        await target.trigger('mouseenter');
+        vi.advanceTimersByTime(100); // Advance timers to account for delay
+
+        // Check if tooltip is in DOM
+        const tooltip = document.querySelector('.vf-tooltip');
+        expect(tooltip).not.toBeNull();
+        expect(tooltip?.textContent).toContain('Test Tooltip');
+
+        wrapper.unmount();
+    });
+
+    it('removes tooltip when target is removed from DOM', async () => {
+        const wrapper = mount(TestComponent, { attachTo: document.body });
+        const target = wrapper.find('#target');
+
+        // Trigger mouseenter
+        await target.trigger('mouseenter');
+        vi.advanceTimersByTime(100);
+
+        // Verify tooltip exists
+        let tooltip = document.querySelector('.vf-tooltip');
+        expect(tooltip).not.toBeNull();
+
+        // Simulate removal of target from DOM
+        // We remove the element directly, bypassing Vue's unmount
+        // This simulates an external library or manual DOM manipulation
+        target.element.remove();
+
+        // Wait for MutationObserver to pick up the change
+        // MutationObserver callbacks are executed as microtasks
+        await Promise.resolve(); // Wait for microtasks
+        vi.advanceTimersByTime(300); // Advance timers just in case (polling fallback or delay)
+        await Promise.resolve();
+
+        // Verify tooltip is gone
+        tooltip = document.querySelector('.vf-tooltip');
+        expect(tooltip).toBeNull();
+
+        wrapper.unmount();
+    });
+});

--- a/src/directives/tooltip.ts
+++ b/src/directives/tooltip.ts
@@ -51,11 +51,8 @@ interface ITooltipOptions {
     alertOnTap?: boolean;
 }
 
-// todo: improve with mutation observer to see removal of node
-
 class VfTooltip {
-    private lastMoveEvt?: MouseEvent;
-    private checkInterval?: ReturnType<typeof setInterval>;
+    private observer?: MutationObserver;
     private shouldShow = false;
     private tipEl?: HTMLElement;
     private titleEl?: HTMLElement;
@@ -136,8 +133,13 @@ class VfTooltip {
 
         this.contentEl[this.config.html ? 'innerHTML' : 'innerText'] = this.config.content;
 
-        if (this.checkInterval) {
-            this.checkInterval = setInterval(() => this.checkMoveEvent(), 250);
+        if (!this.observer) {
+            this.observer = new MutationObserver(() => {
+                if (!this.el.isConnected) {
+                    this.destroy();
+                }
+            });
+            this.observer.observe(document.body, { childList: true, subtree: true });
         }
 
         if (!this.mouseMoveBound) {
@@ -160,9 +162,9 @@ class VfTooltip {
         this.titleEl = undefined;
         this.contentEl = undefined;
 
-        if (this.checkInterval) {
-            clearInterval(this.checkInterval);
-            this.checkInterval = undefined;
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = undefined;
         }
 
         window.removeEventListener('mousemove', this.handleMouseMoveWithContext);
@@ -184,18 +186,6 @@ class VfTooltip {
 
         this.tipEl!.style.left = tipX + 'px';
         this.tipEl!.style.top = tipY + 'px';
-
-        this.lastMoveEvt = e;
-    }
-
-    checkMoveEvent() {
-        if (!this.lastMoveEvt) return;
-
-        if (this.tipEl !== this.lastMoveEvt.target) {
-            if (!this.tipEl?.contains(this.lastMoveEvt.target as Node)) {
-                this.handleTargetMouseLeave();
-            }
-        }
     }
 
     destroy() {

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -7,5 +7,7 @@
         "emitDeclarationOnly": false,
         "noEmit": true,
         "rootDir": "."
-    }
+    },
+    "include": ["src/**/*.ts", "src/**/*.vue", "src/**/__tests__/*"],
+    "exclude": []
 }


### PR DESCRIPTION
Replaced `setInterval` polling with `MutationObserver` in `src/directives/tooltip.ts` to detect when the tooltip target is removed from the DOM.
This ensures cleanup happens even if the removal is not tracked by Vue's lifecycle hooks.
Added a unit test `src/directives/__tests__/tooltip.spec.ts` to verify the fix.
Updated `tsconfig.vitest.json` to include test files.
Removed `checkInterval`, `checkMoveEvent` and `lastMoveEvt` which were part of the removed polling mechanism.

---
*PR created automatically by Jules for task [940335506756863116](https://jules.google.com/task/940335506756863116) started by @fergusean*