### PR TITLE
Fix modal background stacking opacity

### DIFF
--- a/src/components/vf-modal.test.ts
+++ b/src/components/vf-modal.test.ts
@@ -1,0 +1,93 @@
+import { mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { defineComponent, nextTick } from 'vue';
+
+import { OverlayContainer, presentOverlay } from './overlay-container';
+import VfModal from './vf-modal.vue';
+
+// Mock component for a generic overlay (like dropdown)
+const TestDropdown = defineComponent({
+    template: '<div class="test-dropdown">Dropdown Content</div>'
+});
+
+describe('Modal Stacking', () => {
+    let wrapper: VueWrapper;
+
+    beforeEach(() => {
+        // Mount the OverlayContainer which renders the overlays
+        wrapper = mount(OverlayContainer, {
+            attachTo: document.body
+        });
+    });
+
+    afterEach(() => {
+        wrapper.unmount();
+        document.body.innerHTML = '';
+    });
+
+    it('correctly applies is-covered class to stacked modals', async () => {
+        // 1. Open first modal
+        presentOverlay(
+            VfModal,
+            {
+                // @ts-expect-error - 'class' prop is stripped by CleanProps but VfModal accepts it
+                class: 'modal-1'
+            },
+            {}
+        );
+
+        await nextTick();
+        await nextTick();
+        // Allow MutationObserver to fire
+        await new Promise(r => setTimeout(r, 50));
+
+        const modalWraps = () => document.querySelectorAll('.vf-modal-wrap');
+        expect(modalWraps().length).toBe(1);
+        expect(modalWraps()[0]!.classList.contains('is-covered')).toBe(false);
+
+        // 2. Open second modal
+        const p2 = presentOverlay(
+            VfModal,
+            {
+                // @ts-expect-error - 'class' prop is stripped by CleanProps but VfModal accepts it
+                class: 'modal-2',
+                closeOnMaskClick: true
+            },
+            {}
+        );
+
+        await nextTick();
+        await nextTick();
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(modalWraps().length).toBe(2);
+        // First modal should now be covered
+        expect(modalWraps()[0]!.classList.contains('is-covered')).toBe(true);
+        // Second modal should NOT be covered
+        expect(modalWraps()[1]!.classList.contains('is-covered')).toBe(false);
+
+        // 3. Open a non-modal overlay (e.g. dropdown)
+        presentOverlay(TestDropdown, {}, {});
+
+        await nextTick();
+        await nextTick();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Second modal should STILL NOT be covered, because the new overlay is not a modal
+        expect(modalWraps()[1]!.classList.contains('is-covered')).toBe(false);
+
+        // 4. Close the second modal
+        // Simulate Escape key to close the top-most modal (which handles Escape)
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+        await p2; // Wait for closure
+        await nextTick();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Now modal 2 should be gone.
+        expect(modalWraps().length).toBe(1);
+
+        // Modal 1 should NOT be covered anymore
+        expect(modalWraps()[0]!.classList.contains('is-covered')).toBe(false);
+    });
+});

--- a/src/components/vf-modal.vue
+++ b/src/components/vf-modal.vue
@@ -40,10 +40,13 @@ const overlay = ref<HTMLElement>();
 const form = ref<HTMLFormElement>();
 
 const isHidden = ref(false);
+const isCovered = ref(false);
 
 const classList = computed(() => {
-    return compact([...(Array.isArray(props.class) ? props.class : [props.class]), isHidden.value && 'hidden']);
+    return compact([...(Array.isArray(props.class) ? props.class : [props.class]), isHidden.value && 'hidden', isCovered.value && 'is-covered']);
 });
+
+let observer: MutationObserver | undefined;
 
 onMounted(() => {
     document.body.classList.add('vf-modal-open');
@@ -52,6 +55,40 @@ onMounted(() => {
         window.addEventListener('keydown', handleEscapeKey);
         overlay.value?.addEventListener('click', handleOverlayClick);
     }
+
+    const parent = overlay.value?.parentElement;
+    if (parent) {
+        checkIfCovered();
+        observer = new MutationObserver(mutations => {
+            let checkNeeded = false;
+            for (const m of mutations) {
+                if (m.type === 'childList') {
+                    if (m.target === parent) {
+                        checkNeeded = true;
+                        break;
+                    }
+                } else if (m.type === 'attributes' && m.attributeName === 'class') {
+                    // Check if target is a sibling overlay (direct child of parent)
+                    // Note: m.target is Node, need to cast to Element to check parentElement
+                    const target = m.target as Element;
+                    if (target.parentElement === parent) {
+                        checkNeeded = true;
+                        break;
+                    }
+                }
+            }
+            if (checkNeeded) {
+                checkIfCovered();
+            }
+        });
+
+        observer.observe(parent, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['class']
+        });
+    }
 });
 
 onBeforeUnmount(() => {
@@ -59,7 +96,26 @@ onBeforeUnmount(() => {
 
     const areOtherModalsOpen = document.body.querySelectorAll('.vf-modal').length > 0;
     if (!areOtherModalsOpen) document.body.classList.remove('vf-modal-open');
+
+    observer?.disconnect();
 });
+
+function checkIfCovered() {
+    if (!overlay.value || !overlay.value.parentElement) return;
+
+    const siblings = Array.from(overlay.value.parentElement.children);
+    const myIndex = siblings.indexOf(overlay.value);
+
+    let covered = false;
+    for (let i = myIndex + 1; i < siblings.length; i++) {
+        const sibling = siblings[i];
+        if (sibling && sibling.classList.contains('vf-modal-wrap') && !sibling.classList.contains('hidden')) {
+            covered = true;
+            break;
+        }
+    }
+    isCovered.value = covered;
+}
 
 function handleOverlayClick(e: MouseEvent) {
     if (e.target == overlay.value) {
@@ -123,13 +179,11 @@ function unhide() {
     display: flex;
     justify-content: center;
     align-items: center;
-}
 
-// TODO: make modal backgrounds not stack, except don't make the top-most modal transparent if there's
-// a context menu or dropdown on top of it
-// .vf-modal-wrap:not(:last-child) {
-//     background: transparent;
-// }
+    &.is-covered {
+        background: transparent;
+    }
+}
 
 .vf-modal {
     background: white;


### PR DESCRIPTION
- Modified `vf-modal.vue` to track if a modal is covered by another modal using a `MutationObserver`.
- Added `.is-covered` class to modals that are covered by subsequent modals, making their background transparent.
- This prevents the accumulation of background opacity when multiple modals are open.
- Ensures that non-modal overlays (like dropdowns) do not cause the underlying modal to become transparent.
- Added `src/components/vf-modal.test.ts` to verify the behavior.

---
*PR created automatically by Jules for task [10457647002822067106](https://jules.google.com/task/10457647002822067106) started by @fergusean*